### PR TITLE
Progress dashboard bugs fixed and table structure fix

### DIFF
--- a/db/redroomsim.sql
+++ b/db/redroomsim.sql
@@ -27,8 +27,8 @@ CREATE TABLE redroomsimdb.simulation_progress (
     username TEXT NOT NULL,
     score INTEGER,
     completed BOOLEAN,
-    created_at TIMESTAMP DEFAULT now(),
-    UNIQUE (username, scenario_id)
+    created_at TIMESTAMP DEFAULT now()
+    -- allow multiple attempts per user and scenario
 );
 
 CREATE TABLE redroomsimdb.simulation_step_progress (

--- a/frontend/src/components/AdminPanel/AdminAuditLog.jsx
+++ b/frontend/src/components/AdminPanel/AdminAuditLog.jsx
@@ -39,7 +39,6 @@ const AdminAuditLog = () => {
     sortConfig,
     handleSort,
     columnWidths,
-    handleMouseDown,
     sortData,
     getSortSymbol,
   } = useTableSortResize({
@@ -137,7 +136,7 @@ const AdminAuditLog = () => {
   }, []);
 
   return (
-    <div className="bg-white dark:bg-gray-800 dark:text-white rounded-xl shadow p-6">
+    <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-xl shadow p-6">
       <h2 className="text-xl font-bold mb-4">Admin Audit Log</h2>
       {loading ? (
         <p>Loading...</p>
@@ -200,7 +199,7 @@ const AdminAuditLog = () => {
               Download
             </button>
           </div>
-          <table className="min-w-full border-collapse table-fixed">
+          <table className="w-full border-collapse table-auto">
             <thead className="bg-gray-100 dark:bg-gray-700">
               <tr>
                 <th
@@ -214,11 +213,7 @@ const AdminAuditLog = () => {
                     >
                       Actor {getSortSymbol('actor')}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown('actor', e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -232,11 +227,7 @@ const AdminAuditLog = () => {
                     >
                       Action {getSortSymbol('action')}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown('action', e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -250,11 +241,7 @@ const AdminAuditLog = () => {
                     >
                       Details {getSortSymbol('details')}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown('details', e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -268,11 +255,7 @@ const AdminAuditLog = () => {
                     >
                       Screen {getSortSymbol('screen')}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown('screen', e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -286,11 +269,7 @@ const AdminAuditLog = () => {
                     >
                       Timestamp {getSortSymbol('timestamp')}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown('timestamp', e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
               </tr>

--- a/frontend/src/components/AdminPanel/AdminUserList.jsx
+++ b/frontend/src/components/AdminPanel/AdminUserList.jsx
@@ -35,7 +35,6 @@ const AdminUserList = () => {
     sortConfig,
     handleSort,
     columnWidths,
-    handleMouseDown,
     sortData,
     getSortSymbol,
   } = useTableSortResize({
@@ -107,7 +106,7 @@ const AdminUserList = () => {
 
   return (
     <>
-      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-6">
+      <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-xl shadow p-6 mb-6">
         <h2 className="text-2xl font-bold mb-4">Manage User</h2>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
           <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded shadow">
@@ -136,7 +135,7 @@ const AdminUserList = () => {
         />
 
         <div className="overflow-x-auto">
-          <table className="min-w-full bg-white dark:bg-gray-800 rounded shadow overflow-hidden table-fixed">
+          <table className="w-full border-collapse table-auto">
           <thead className="bg-gray-200 dark:bg-gray-700 text-left">
             <tr>
               <th style={{ width: columnWidths.name }} className="px-4 py-2">
@@ -147,11 +146,7 @@ const AdminUserList = () => {
                   >
                     Name {getSortSymbol('name')}
                   </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('name', e)}
-                  >|
-                  </span>
+                  {/* Resizer removed */}
                 </div>
               </th>
               <th style={{ width: columnWidths.email }} className="px-4 py-2">
@@ -162,11 +157,7 @@ const AdminUserList = () => {
                   >
                     Email {getSortSymbol('email')}
                   </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('email', e)}
-                  >|
-                  </span>
+                  {/* Resizer removed */}
                 </div>
               </th>
               <th style={{ width: columnWidths.role }} className="px-4 py-2">
@@ -177,11 +168,7 @@ const AdminUserList = () => {
                   >
                     Role {getSortSymbol('role')}
                   </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('role', e)}
-                  >|
-                  </span>
+                  {/* Resizer removed */}
                 </div>
               </th>
               <th style={{ width: columnWidths.designation }} className="px-4 py-2">
@@ -192,11 +179,7 @@ const AdminUserList = () => {
                   >
                     Designation {getSortSymbol('designation')}
                   </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('designation', e)}
-                  >|
-                  </span>
+                  {/* Resizer removed */}
                 </div>
               </th>
               <th style={{ width: columnWidths.status }} className="px-4 py-2">
@@ -207,11 +190,7 @@ const AdminUserList = () => {
                   >
                     Account Status {getSortSymbol('status')}
                   </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('status', e)}
-                  >|
-                  </span>
+                  {/* Resizer removed */}
                 </div>
               </th>
               <th className="px-4 py-2">Actions</th>

--- a/frontend/src/components/AdminPanel/ScenarioConfigurator.jsx
+++ b/frontend/src/components/AdminPanel/ScenarioConfigurator.jsx
@@ -26,7 +26,6 @@ const ScenarioConfigurator = () => {
     sortConfig,
     handleSort,
     columnWidths,
-    handleMouseDown,
     sortData,
     getSortSymbol,
   } = useTableSortResize({ name: 200, type: 150, difficulty: 120 });
@@ -62,91 +61,72 @@ const ScenarioConfigurator = () => {
   const sortedScenarios = sortData(scenarios);
 
   return (
-    <div className="bg-white dark:bg-gray-800 dark:text-white rounded-xl shadow p-6">
+    <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-xl shadow p-6">
       <h2 className="text-xl font-bold mb-4">Scenario Configurator</h2>
       {loading ? (
         <p>Loading...</p>
       ) : scenarios.length === 0 ? (
         <p className="text-gray-700 dark:text-gray-300">No scenarios found.</p>
       ) : (
-        <table className="min-w-full border-collapse table-fixed text-gray-900 dark:text-white">
-          <thead className="bg-gray-100 dark:bg-gray-700">
-            <tr>
-              <th
-                style={{ width: columnWidths.name }}
-                className="border dark:border-gray-600 px-4 py-2 text-left"
-              >
-                <div className="flex items-center">
-                  <span
-                    className="cursor-pointer"
-                    onClick={() => handleSort('name')}
-                  >
-                    Name {getSortSymbol('name')}
-                  </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('name', e)}
-                  >|
-                  </span>
-                </div>
-              </th>
-              <th
-                style={{ width: columnWidths.type }}
-                className="border dark:border-gray-600 px-4 py-2 text-left"
-              >
-                <div className="flex items-center">
-                  <span
-                    className="cursor-pointer"
-                    onClick={() => handleSort('type')}
-                  >
-                    Type {getSortSymbol('type')}
-                  </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('type', e)}
-                  >|
-                  </span>
-                </div>
-              </th>
-              <th
-                style={{ width: columnWidths.difficulty }}
-                className="border dark:border-gray-600 px-4 py-2 text-left"
-              >
-                <div className="flex items-center">
-                  <span
-                    className="cursor-pointer"
-                    onClick={() => handleSort('difficulty')}
-                  >
-                    Difficulty {getSortSymbol('difficulty')}
-                  </span>
-                  <span
-                    className="ml-2 cursor-col-resize select-none px-1"
-                    onMouseDown={(e) => handleMouseDown('difficulty', e)}
-                  >|
-                  </span>
-                </div>
-              </th>
-              <th className="border dark:border-gray-600 px-4 py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {sortedScenarios.map((sc) => (
-              <tr key={sc.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
-                <td style={{ width: columnWidths.name }} className="border dark:border-gray-600 px-4 py-2">{sc.name}</td>
-                <td style={{ width: columnWidths.type }} className="border dark:border-gray-600 px-4 py-2">{sc.type}</td>
-                <td style={{ width: columnWidths.difficulty }} className="border dark:border-gray-600 px-4 py-2">{sc.difficulty}</td>
-                <td className="border dark:border-gray-600 px-4 py-2 text-center">
-                  <button
-                    onClick={() => deleteScenario(sc.id)}
-                    className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700"
-                  >
-                    Delete
-                  </button>
-                </td>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse table-auto">
+            <thead className="bg-gray-100 dark:bg-gray-700 text-left">
+              <tr>
+                <th style={{ width: columnWidths.name }} className="px-6 py-3 text-left">
+                  <div className="flex items-center">
+                    <span
+                      className="cursor-pointer"
+                      onClick={() => handleSort('name')}
+                    >
+                      Name {getSortSymbol('name')}
+                    </span>
+                    {/* Resizer removed */}
+                  </div>
+                </th>
+                <th style={{ width: columnWidths.type }} className="px-6 py-3 text-left">
+                  <div className="flex items-center">
+                    <span
+                      className="cursor-pointer"
+                      onClick={() => handleSort('type')}
+                    >
+                      Type {getSortSymbol('type')}
+                    </span>
+                    {/* Resizer removed */}
+                  </div>
+                </th>
+                <th style={{ width: columnWidths.difficulty }} className="px-6 py-3 text-left">
+                  <div className="flex items-center">
+                    <span
+                      className="cursor-pointer"
+                      onClick={() => handleSort('difficulty')}
+                    >
+                      Difficulty {getSortSymbol('difficulty')}
+                    </span>
+                    {/* Resizer removed */}
+                  </div>
+                </th>
+                <th className="px-6 py-3" />
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {sortedScenarios.map((sc) => (
+                <tr key={sc.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                  <td style={{ width: columnWidths.name }} className="border dark:border-gray-600 px-4 py-2">{sc.name}</td>
+                  <td style={{ width: columnWidths.type }} className="border dark:border-gray-600 px-4 py-2">{sc.type}</td>
+                  <td style={{ width: columnWidths.difficulty }} className="border dark:border-gray-600 px-4 py-2">{sc.difficulty}</td>
+                  <td className="border dark:border-gray-600 px-4 py-2 text-center">
+                    <button
+                      onClick={() => deleteScenario(sc.id)}
+                      className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/AdminPanel/UserMonitoringTable.jsx
+++ b/frontend/src/components/AdminPanel/UserMonitoringTable.jsx
@@ -37,7 +37,6 @@ const UserMonitoringTable = () => {
     sortConfig,
     handleSort,
     columnWidths,
-    handleMouseDown,
     sortData,
     getSortSymbol,
   } = useTableSortResize({ email: 150, role: 120, event: 150, timestamp: 200 });
@@ -155,7 +154,7 @@ const UserMonitoringTable = () => {
         <p>No user activity found.</p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full border-collapse table-fixed">
+          <table className="w-full border-collapse table-auto">
             <thead className="bg-gray-100 dark:bg-gray-700">
               <tr>
                 <th
@@ -169,11 +168,7 @@ const UserMonitoringTable = () => {
                     >
                       Email {getSortSymbol("email")}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown("email", e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -187,11 +182,7 @@ const UserMonitoringTable = () => {
                     >
                       Role {getSortSymbol("role")}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown("role", e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -205,11 +196,7 @@ const UserMonitoringTable = () => {
                     >
                       Event {getSortSymbol("event")}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown("event", e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
                 <th
@@ -223,11 +210,7 @@ const UserMonitoringTable = () => {
                     >
                       Timestamp {getSortSymbol("timestamp")}
                     </span>
-                    <span
-                      className="ml-2 cursor-col-resize select-none px-1"
-                      onMouseDown={(e) => handleMouseDown("timestamp", e)}
-                    >|
-                    </span>
+                    {/* Resizer removed */}
                   </div>
                 </th>
               </tr>

--- a/frontend/src/pages/Simulation.jsx
+++ b/frontend/src/pages/Simulation.jsx
@@ -59,7 +59,9 @@ const Simulation = () => {
           map[s.id] = idx; // store mapping for branch navigation
         });
         setStepMap(map); // save map in state
-        setAnalytics((prev) => ({ ...prev, startTime: Date.now() }));
+        const now = Date.now();
+        setAnalytics((prev) => ({ ...prev, startTime: now }));
+        setStartTime(now); // track when the scenario was first loaded
       } catch (error) {
         console.error("Failed to load scenario", error);
       }

--- a/infra/fastapi-lambda/app/models/progress_models.py
+++ b/infra/fastapi-lambda/app/models/progress_models.py
@@ -6,17 +6,13 @@ from sqlalchemy import (
     DateTime,
     func,
     ForeignKey,
-    UniqueConstraint,
 )
 from db import Base
 
 
 class SimulationProgress(Base):
     __tablename__ = "simulation_progress"
-    __table_args__ = (
-        UniqueConstraint("username", "scenario_id", name="username_scenario_uc"),
-        {"schema": "redroomsimdb"},
-    )
+    __table_args__ = ({"schema": "redroomsimdb"},)
 
     id = Column(Integer, primary_key=True, index=True)
     sim_uuid = Column(String, unique=True, nullable=False)

--- a/infra/fastapi-lambda/app/routes/progress_router.py
+++ b/infra/fastapi-lambda/app/routes/progress_router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import func
 from db import SessionLocal
+from datetime import datetime
 from models.progress_models import SimulationProgress, SimulationStepProgress
 from pydantic import BaseModel
 import uuid
@@ -44,28 +45,16 @@ def save_progress(progress: ProgressIn):
             db.refresh(record)
             return {"simulation_id": record.sim_uuid}
         else:
-            existing = (
-                db.query(SimulationProgress)
-                .filter_by(username=progress.username, scenario_id=progress.scenario_id)
-                .first()
-            )
             sim_uuid = str(uuid.uuid4())
-            if existing:
-                existing.sim_uuid = sim_uuid
-                existing.name = progress.name
-                existing.score = progress.score
-                existing.completed = progress.completed
-                record = existing
-            else:
-                record = SimulationProgress(
-                    sim_uuid=sim_uuid,
-                    scenario_id=progress.scenario_id,
-                    name=progress.name,
-                    username=progress.username,
-                    score=progress.score,
-                    completed=progress.completed,
-                )
-                db.add(record)
+            record = SimulationProgress(
+                sim_uuid=sim_uuid,
+                scenario_id=progress.scenario_id,
+                name=progress.name,
+                username=progress.username,
+                score=progress.score,
+                completed=progress.completed,
+            )
+            db.add(record)
             db.commit()
             db.refresh(record)
             return {"simulation_id": sim_uuid}
@@ -86,12 +75,37 @@ def save_step_progress(step: StepProgressIn):
             .scalar()
         )
         next_sequence = (last_sequence or 0) + 1
+        
+        time_ms = step.time_ms
+        # ensure we store a reasonable duration for this step
+        if time_ms is None or time_ms > 2_000_000_000:
+            # compute duration relative to previous step or start time
+            last_record = (
+                db.query(SimulationStepProgress)
+                .filter_by(sim_uuid=step.sim_uuid)
+                .order_by(SimulationStepProgress.sequence.desc())
+                .first()
+            )
+            base_time = last_record.created_at if last_record else None
+            if base_time is None:
+                start_record = (
+                    db.query(SimulationProgress)
+                    .filter_by(sim_uuid=step.sim_uuid)
+                    .first()
+                )
+                base_time = start_record.created_at if start_record else None
+            if base_time is not None:
+                delta = datetime.utcnow() - base_time
+                time_ms = int(delta.total_seconds() * 1000)
+            else:
+                time_ms = 0
+
         record = SimulationStepProgress(
             sim_uuid=step.sim_uuid,
             step_index=step.step_index,
             decision=step.decision,
             feedback=step.feedback,
-            time_ms=step.time_ms,
+            time_ms=time_ms,
             sequence=next_sequence,
         )
         db.add(record)
@@ -160,7 +174,12 @@ def get_timeline(simulation_id: str):
 def get_user_progress(username: str):
     db = SessionLocal()
     try:
-        records = db.query(SimulationProgress).filter_by(username=username).all()
+        records = (
+            db.query(SimulationProgress)
+            .filter_by(username=username)
+            .order_by(SimulationProgress.created_at.desc())
+            .all()
+        )
         return [
             {
                 "id": r.id,


### PR DESCRIPTION
## Summary
- show pass/fail in the progress dashboard when a simulation is completed
  - pass if score >= 70%
  - fail otherwise
- update table structure to include new column
- update progress dashboard to convert scores into percentages
- fetch scenario step counts so percentages can be calculated
- allow multiple attempts per scenario in the database
- update ORM model accordingly
- simplify progress creation logic so each run creates a new record
- standardize table containers to match User Monitoring style
- remove column resize controls from all tables