### PR TITLE
dashboard, simulation cleanup, upload evidence and contact page

### DIFF
--- a/frontend/src/components/Shared/Sidebar.jsx
+++ b/frontend/src/components/Shared/Sidebar.jsx
@@ -91,7 +91,7 @@ const Sidebar = ({ isOpen, toggleSidebar }) => {
             )}
             <Link to="/upload" className="flex items-center space-x-3 py-2 px-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
               <span className="text-2xl">📤</span>
-              {isOpen && <span>Upload Evidence</span>}
+              {isOpen && <span>Upload Scenario</span>}
             </Link>
           </>
         )}

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -21,7 +21,16 @@ const ContactPage = () => {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Contact Us</h1>
-      <p>If you need assistance, please contact our support team at <a href="mailto:support@redroomsim.com" className="text-red-500">support@redroomsim.com</a>.</p>
+      <p>
+        If you need assistance, please open an issue on our {' '}
+        <a
+          href="https://github.com/RedRoomSim/redroomsim/issues"
+          className="text-red-500"
+        >
+          GitHub repository
+        </a>
+        .
+      </p>
     </div>
   );
 };

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -26,7 +26,9 @@ import ProgressTracker from "../components/ProgressDashboard/ProgressTracker";
 const Dashboard = () => {
   return (
     <div>
+      {/*
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      */}
       <ProgressTracker />
     </div>
   );

--- a/frontend/src/pages/Simulation.jsx
+++ b/frontend/src/pages/Simulation.jsx
@@ -273,8 +273,8 @@ const Simulation = () => {
                 </p>
                 {simulationId && (
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Simulation ID: {simulationId}
-                  </p> // corrected attribute name
+                    {/*Simulation ID: {simulationId}*/}
+                  </p>
                 )}
 
                 {Object.keys(mitreScores).length > 0 && (


### PR DESCRIPTION
## Summary
- rename the sidebar upload link to **Upload Scenario**
- update contact page to direct users to GitHub issues
- remove simulation id from result page
- remove extra title dashboard from progress dashoard